### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["*"]


### PR DESCRIPTION
Potential fix for [https://github.com/Ga2526-RPL-MA/rpl-sintesa/security/code-scanning/1](https://github.com/Ga2526-RPL-MA/rpl-sintesa/security/code-scanning/1)

To fix this issue, you should add a `permissions` block to your workflow. For a typical lint/build workflow that only needs to read the repository contents, add `permissions: contents: read` at either the root of the workflow (to apply to all jobs), or under the specific job(s), if you want different permissions per job. In this case, since there is only one job ("build"), adding the block at either level is OK, but best practice is to set it at the root unless you expect multiple jobs with varying permissions in the future. The change must be made near the top of the file, below the `name:` or `on:` blocks, and before `jobs:` (if using workflow-level permissions). No imports or further modifications are necessary—just insert the required YAML block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
